### PR TITLE
Fix to add extra KVs for profile spans

### DIFF
--- a/v1/tv/layer.go
+++ b/v1/tv/layer.go
@@ -266,7 +266,8 @@ func newProfile(tvCtx traceview.Context, profileName string, parent Layer, args 
 	); err != nil {
 		return &nullSpan{}
 	}
-	p := &profileSpan{span{tvCtx: tvCtx.Copy(), labeler: pl, parent: parent}}
+	p := &profileSpan{span{tvCtx: tvCtx.Copy(), labeler: pl, parent: parent,
+		endArgs: []interface{}{"Language", "go", "ProfileName", profileName}}}
 	if parent != nil && parent.ok() {
 		parent.addProfile(p)
 	}

--- a/v1/tv/profile_test.go
+++ b/v1/tv/profile_test.go
@@ -5,10 +5,10 @@ package tv_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/tracelytics/go-traceview/v1/tv"
 	g "github.com/tracelytics/go-traceview/v1/tv/internal/graphtest"
 	"github.com/tracelytics/go-traceview/v1/tv/internal/traceview"
-	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
@@ -56,7 +56,10 @@ func TestBeginLayerProfile(t *testing.T) {
 			assert.Equal(t, n.Map["FunctionName"], "github.com/tracelytics/go-traceview/v1/tv_test.testLayerProf")
 			assert.Contains(t, n.Map["File"], "/go-traceview/v1/tv/profile_test.go")
 		}},
-		{"", "profile_exit"}:  {Edges: g.Edges{{"", "profile_entry"}}},
+		{"", "profile_exit"}: {Edges: g.Edges{{"", "profile_entry"}}, Callback: func(n g.Node) {
+			assert.Equal(t, n.Map["Language"], "go")
+			assert.Equal(t, n.Map["ProfileName"], "testLayerProf")
+		}},
 		{"L1", "exit"}:        {Edges: g.Edges{{"", "profile_exit"}, {"L1", "entry"}}},
 		{"testLayer", "exit"}: {Edges: g.Edges{{"L1", "exit"}, {"testLayer", "entry"}}},
 	})


### PR DESCRIPTION
This ensures that a named profile spans will show up as filterable items in the TraceView dashboard, rather than just on the trace details page.
